### PR TITLE
Set function permissions anonymous

### DIFF
--- a/mailing/function.json
+++ b/mailing/function.json
@@ -1,7 +1,7 @@
 {
   "bindings": [
     {
-      "authLevel": "function",
+      "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",


### PR DESCRIPTION
We didn't integrate the function codes Azure generated in favor of our own universal API key, so the permissions need to be set to "anonymous" as to not expose the function key